### PR TITLE
Fix: Correct Dockerfile and docker-compose.yml paths

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -11,7 +11,7 @@ RUN dotnet restore "ItauChallenge.Api/ItauChallenge.Api.csproj"
 # Copia todo o código fonte e publica a aplicação
 # WORKDIR /src # Already in /src
 COPY . .
-WORKDIR "/src/ItauChallenge.Api"
+WORKDIR "/src/src/ItauChallenge.Api"
 RUN dotnet publish "ItauChallenge.Api.csproj" -c Release -o /app/publish
 
 # Estágio 2: Execução da aplicação

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # Serviço do Banco de Dados MySQL
   mysql_db:
@@ -19,7 +17,7 @@ services:
     container_name: itau-api
     build:
       context: ..
-      dockerfile: Dockerfile # This should be Dockerfile, not src/Dockerfile as Dockerfile is in the root
+      dockerfile: deployment/Dockerfile # This should be Dockerfile, not src/Dockerfile as Dockerfile is in the root
     restart: unless-stopped
     ports:
       - "8080:8080" # Mapeia a porta 8080 do container para a 8080 do seu localhost


### PR DESCRIPTION
- I adjusted the WORKDIR in your Dockerfile to correctly locate the .csproj file. The previous WORKDIR "/src/ItauChallenge.Api" was incorrect because the COPY . . command brought the entire project structure, including the 'src' directory, into the container's /src directory. The correct path to the .csproj is /src/src/ItauChallenge.Api.

- I updated the dockerfile path in your docker-compose.yml. The context is '..', so the Dockerfile path needs to be 'deployment/Dockerfile'.

- I removed the obsolete 'version' attribute from your docker-compose.yml. This attribute is no longer needed and causes a warning.