### PR TITLE
docs: Add section on scalability and load balancing to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,60 @@ cd test/ItauChallenge.Domain.Tests # Exemplo
 dotnet test
 ```
 
+## Escalabilidade e Balanceamento de Carga
+
+Com o crescimento do sistema para 1 milhão de operações/dia, é crucial implementar estratégias de escalabilidade e balanceamento de carga para garantir a disponibilidade e o desempenho do serviço.
+
+### Auto-scaling Horizontal
+
+O auto-scaling horizontal ajusta automaticamente o número de instâncias do serviço em execução com base na demanda. Para aplicar o auto-scaling horizontal no serviço, podemos seguir estas etapas:
+
+1.  **Conteinerização:** Empacotar a aplicação em contêineres Docker. Isso já está parcialmente configurado no projeto com o `Dockerfile` e `docker-compose.yml`.
+2.  **Orquestração de Contêineres:** Utilizar uma plataforma de orquestração de contêineres como Kubernetes (K8s) ou AWS Elastic Container Service (ECS). Essas plataformas gerenciam o ciclo de vida dos contêineres, incluindo a escalabilidade.
+3.  **Definição de Métricas de Escalabilidade:** Configurar métricas que dispararão o auto-scaling. As métricas comuns incluem:
+    *   **Uso de CPU:** Aumentar o número de instâncias quando o uso médio de CPU exceder um limite (por exemplo, 70%).
+    *   **Uso de Memória:** Escalar quando o consumo de memória atingir um patamar crítico.
+    *   **Número de Requisições por Segundo (RPS):** Adicionar mais instâncias se o número de requisições por instância ultrapassar um valor definido.
+    *   **Latência da Aplicação:** Escalar se a latência média das respostas aumentar além de um threshold aceitável.
+    *   **Métricas Personalizadas:** Dependendo da natureza do serviço, métricas específicas do negócio (por exemplo, tamanho de filas de processamento) podem ser usadas.
+4.  **Configuração do Auto-scaler:**
+    *   **No Kubernetes:** Utilizar o Horizontal Pod Autoscaler (HPA). O HPA monitora as métricas definidas e ajusta o número de pods (instâncias da aplicação) no deployment. É necessário ter um Metrics Server configurado no cluster.
+    *   **Em Provedores de Nuvem (AWS, Azure, GCP):**
+        *   **AWS:** Utilizar o Application Auto Scaling com ECS ou EC2 Auto Scaling Groups se estiver executando em instâncias EC2.
+        *   **Azure:** Utilizar o Azure Autoscale para Virtual Machine Scale Sets ou Azure App Service.
+        *   **GCP:** Utilizar o Autoscaler para Managed Instance Groups (MIGs) ou Google Kubernetes Engine (GKE).
+5.  **Testes e Monitoramento:** Após a configuração, realizar testes de carga para verificar se o auto-scaling está funcionando conforme o esperado e monitorar continuamente o comportamento do sistema em produção.
+
+### Comparação de Estratégias de Balanceamento de Carga
+
+O balanceador de carga distribui o tráfego de entrada entre as várias instâncias do serviço, melhorando a disponibilidade e a eficiência. Duas estratégias comuns são:
+
+#### Round-Robin
+
+*   **Como Funciona:** Distribui as requisições sequencialmente para cada servidor disponível na lista. Se houver três servidores (A, B, C), a primeira requisição vai para A, a segunda para B, a terceira para C, a quarta para A novamente, e assim por diante.
+*   **Prós:**
+    *   Simples de implementar e entender.
+    *   Distribuição uniforme do tráfego, supondo que todos os servidores tenham capacidade similar.
+*   **Contras:**
+    *   Não leva em consideração a carga atual ou a saúde de cada servidor. Um servidor sobrecarregado ou lento continuará recebendo requisições na sua vez.
+    *   Pode levar a um desempenho degradado se houver disparidade na capacidade ou no estado dos servidores.
+*   **Quando Usar:** Ideal para cenários onde os servidores têm capacidades homogêneas e as cargas de trabalho são relativamente uniformes e previsíveis.
+
+#### Latência (Least Response Time)
+
+*   **Como Funciona:** O balanceador de carga envia a requisição para o servidor que está respondendo mais rapidamente no momento (menor latência). Alguns sistemas também podem combinar isso com o menor número de conexões ativas (Least Connections).
+*   **Prós:**
+    *   Adapta-se dinamicamente às condições da rede e à carga dos servidores.
+    *   Pode melhorar significativamente o tempo de resposta percebido pelo usuário, pois as requisições são direcionadas aos servidores mais ágeis.
+    *   Leva em consideração a saúde e a performance atual de cada servidor.
+*   **Contras:**
+    *   Mais complexo de implementar, pois requer monitoramento contínuo da latência de cada servidor.
+    *   Pode, em alguns casos, sobrecarregar os servidores mais rápidos se não houver um mecanismo para evitar que recebam todas as novas requisições após uma recuperação rápida.
+    *   O cálculo da latência pode adicionar um pequeno overhead.
+*   **Quando Usar:** Preferível para aplicações onde o tempo de resposta é crítico e onde a carga nos servidores ou as condições da rede podem variar significativamente. É uma boa escolha para garantir uma experiência de usuário mais consistente e rápida.
+
+Considerando um volume de 1 milhão de operações/dia, uma estratégia baseada em **latência** (ou uma combinação como Least Connections + Fastest Response Time) é geralmente mais adequada, pois otimiza a performance e a resiliência, direcionando o tráfego para as instâncias que podem processá-lo mais eficientemente no momento.
+
 ## Easter Eggs
 
 Aqui detalhamos algumas das mensagens ocultas e seus significados:


### PR DESCRIPTION
This commit introduces a new section to the README.md file titled "Escalabilidade e Balanceamento de Carga".

This section addresses the scenario of the system growing to 1 million operations/day by:
- Explaining how to apply horizontal auto-scaling to the service, covering containerization, orchestration, metrics definition, and auto-scaler configuration on platforms like Kubernetes and major cloud providers.
- Comparing load balancing strategies, specifically Round-Robin and Latency-based (Least Response Time), detailing their pros, cons, and ideal use cases.

The new content is placed before the "Easter Eggs" section.