### PR TITLE
feat: Implement real-time P&L updates and optimize operations query

### DIFF
--- a/src/ItauChallenge.Domain/Position.cs
+++ b/src/ItauChallenge.Domain/Position.cs
@@ -9,6 +9,7 @@ namespace ItauChallenge.Domain
         public int AssetId { get; set; }
         public int Quantity { get; set; }
         public decimal AveragePrice { get; set; }
+        public decimal PL { get; set; } // Added property for Profit and Loss
         public DateTime UpdatedDth { get; set; }
         public DateTime CreatedDth { get; set; }
 


### PR DESCRIPTION
This commit introduces several enhancements related to financial calculations and data retrieval:

1.  I optimized `GetUserOperationsAsync` in `DatabaseService.cs` by adding an `ORDER BY operation_dth DESC` clause to its SQL query. This ensures better utilization of the existing `idx_op_usr_ast_dth` index for improved performance when fetching your operations.

2.  I aligned the `Position` domain model (`Position.cs`) with the database schema by adding a `PL` (Profit and Loss) property. This corresponds to the `pos_pl` column in the `pos` table.

3.  I implemented real-time P&L calculation in `UpdateClientPositionsAsync` method in `DatabaseService.cs`. When a new asset quote is received, this method now:
    *   Calculates P&L using the formula: `(quantity * newPrice) - (quantity * average_price)`.
    *   Updates the `pos_pl` column in the `pos` table for the affected asset.
    *   Updates the `updated_dth` timestamp for the modified positions.

4.  I updated `GetClientPositionsAsync` in `DatabaseService.cs` to select the `pos_pl` column, mapping it to the new `PL` property in the `Position` domain model.

5.  I added a clarifying comment in `UpdateClientPositionsAsync` regarding the calculation of average price, noting that it's typically affected by buy/sell operations rather than solely by market quote fluctuations.

6.  I included new unit tests in `DatabaseServiceTests.cs` for the `UpdateClientPositionsAsync` method. These tests cover scenarios for positive, negative, and zero P&L calculations and verify the update of the position's timestamp.