### PR TITLE
Add endpoint for user creation

### DIFF
--- a/src/ItauChallenge.Api/Controllers/UsersController.cs
+++ b/src/ItauChallenge.Api/Controllers/UsersController.cs
@@ -74,4 +74,35 @@ public class UsersController : ControllerBase
         };
         return Ok(dto);
     }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(User), 201)] // Assuming User domain object is returned
+    [ProducesResponseType(400)]
+    public async Task<IActionResult> CreateUser([FromBody] CreateUserDto createUserDto)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ModelState);
+        }
+
+        var user = new User
+        {
+            Name = createUserDto.Name,
+            Email = createUserDto.Email
+            // CreatedDth will be set by the service/database
+        };
+
+        // The service method now takes brokeragePercent as a separate parameter
+        var createdUser = await _databaseService.CreateUserAsync(user, createUserDto.BrokeragePercent);
+
+        // Return a 201 Created response with the location of the new resource and the resource itself
+        // The location URL might need adjustment based on how one would typically retrieve a single user (e.g., GET /api/v1/users/{id})
+        // For now, returning the created user object directly.
+        // A common practice is return CreatedAtAction or CreatedAtRoute.
+        // Let's assume a GetUserById method exists or will exist for the Location header.
+        // If not, we can return Ok(createdUser) or just the createdUser for simplicity as per initial thought.
+        // For now, returning 201 with the object. A `Location` header is best practice.
+        // To keep it simple for now, and since there isn't a GET endpoint for a single user yet:
+        return StatusCode(201, createdUser);
+    }
 }

--- a/src/ItauChallenge.Api/Dtos/CreateUserDto.cs
+++ b/src/ItauChallenge.Api/Dtos/CreateUserDto.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ItauChallenge.Api.Dtos
+{
+    public class CreateUserDto
+    {
+        [Required]
+        [StringLength(255)]
+        public string Name { get; set; }
+
+        [Required]
+        [EmailAddress]
+        [StringLength(255)]
+        public string Email { get; set; }
+
+        [Required]
+        [Range(0, 0.9999)] // Example range for brokerage percent, allowing 0.0000 to 0.9999
+        public decimal BrokeragePercent { get; set; }
+    }
+}

--- a/src/ItauChallenge.Infra/DatabaseService.cs
+++ b/src/ItauChallenge.Infra/DatabaseService.cs
@@ -267,6 +267,22 @@ namespace ItauChallenge.Infra
     }
 }
 
+        public async Task<User> CreateUserAsync(User user, decimal brokeragePercent)
+        {
+            const string sql = @"
+                INSERT INTO usr (usr_name, usr_email, usr_brokerage_pct)
+                VALUES (@Name, @Email, @BrokeragePercent);
+                SELECT LAST_INSERT_ID();";
+
+            using (var connection = new MySqlConnection(_connectionString))
+            {
+                var newUserId = await connection.ExecuteScalarAsync<int>(sql, new { user.Name, user.Email, BrokeragePercent = brokeragePercent });
+                user.Id = newUserId;
+                user.CreatedDth = DateTime.UtcNow;
+                return user;
+            }
+        }
+
         // New methods for API controllers
         public async Task<Quote> GetLatestQuoteAsync(int assetId)
         {

--- a/src/ItauChallenge.Infra/IDatabaseService.cs
+++ b/src/ItauChallenge.Infra/IDatabaseService.cs
@@ -11,6 +11,7 @@ namespace ItauChallenge.Infra
         Task SaveQuoteAsync(Quote quote, string messageId);
         Task<bool> IsMessageProcessedAsync(string messageId);
         Task UpdateClientPositionsAsync(int assetId, decimal newPrice);
+        Task<User> CreateUserAsync(User user, decimal brokeragePercent);
 
         // New methods for API controllers
         Task<Quote> GetLatestQuoteAsync(int assetId);


### PR DESCRIPTION
This commit introduces new functionality to create users through the API.

Key changes include:
- Added a `CreateUserDto` for handling user creation request data (name, email, brokerage percent).
- Extended `IDatabaseService` and `DatabaseService` with a `CreateUserAsync` method to persist new users to the `usr` table, correctly handling brokerage percentage.
- Implemented a new POST endpoint `/api/v1/users` in `UsersController` that accepts the `CreateUserDto` and orchestrates user creation.

This enables clients to add new users, such as "guilherme camarao" with a specified email and brokerage percentage, to the system.