### PR TITLE
Fix: Resolve solution build errors

### DIFF
--- a/src/ItauChallenge.Contracts/Dtos/PortfolioDto.cs
+++ b/src/ItauChallenge.Contracts/Dtos/PortfolioDto.cs
@@ -1,0 +1,8 @@
+namespace ItauChallenge.Contracts.Dtos
+{
+    public class PortfolioDto
+    {
+        public IEnumerable<ClientPositionDto> Positions { get; set; }
+        public decimal Consolidated { get; set; }
+    }
+}

--- a/src/ItauChallenge.Contracts/ItauChallenge.Contracts.csproj
+++ b/src/ItauChallenge.Contracts/ItauChallenge.Contracts.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
 </Project>

--- a/src/ItauChallenge.QuotesConsumer/ItauChallenge.QuotesConsumer.csproj
+++ b/src/ItauChallenge.QuotesConsumer/ItauChallenge.QuotesConsumer.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\ItauChallenge.Application\ItauChallenge.Application.csproj" />
     <ProjectReference Include="..\ItauChallenge.Domain\ItauChallenge.Domain.csproj" />
     <ProjectReference Include="..\ItauChallenge.Infra\ItauChallenge.Infra.csproj" />
+    <ProjectReference Include="..\ItauChallenge.Contracts\ItauChallenge.Contracts.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The solution was failing to build due to issues with project references, primarily:
- The ItauChallenge.Contracts project was not being correctly recognized by other projects.
- A specific ProjectReference to ItauChallenge.Contracts was missing in ItauChallenge.QuotesConsumer.csproj.

This commit addresses these issues by:
1. Ensuring `dotnet restore` can correctly process all projects.
2. Adding the missing ProjectReference from ItauChallenge.QuotesConsumer to ItauChallenge.Contracts.

After these changes, the solution builds successfully. There are remaining warnings that can be addressed separately.